### PR TITLE
Cleaning probabilistic maps

### DIFF
--- a/scripts/SLF123/README.md
+++ b/scripts/SLF123/README.md
@@ -11,7 +11,9 @@ database.
   3. transform.sh: transform native ROIs to the warped brain to obtain ROIs in the reference space
 
 - if ROIs are in mat, before transform  convert them to Nifti by running rois_mat2nifti.m
-- probabilisticMap.m : once registration and transformation are completed, run this matlab script to obtain the probabilistic maps
+- probabilisticMap.m : once registration and transformation are completed, run this matlab script to obtain the probabilistic maps. Furtheremore, it contains the option of cleaning the maps, i.e., select one ROI for the voxels that are labeled by more than one ROI (it selects the ROI with higher number of subjects for those voxels).
+
+- probabilisticMap folder: it contains all the matlab functions needed for the probabilisticMap.m
 
 ## Usage
 

--- a/scripts/SLF123/SLF123.py
+++ b/scripts/SLF123/SLF123.py
@@ -105,3 +105,10 @@ elif script == "skullStripping.sh":
     print(cmdstr)
     sp.call(cmdstr, shell=True)
 
+elif script == "binarize.sh":
+    cmdstr = (f"{codedir}/binarize.sh "+
+	       f"-b {basedir} " +
+	       f"-f {fsl_ver} ")
+    print(cmdstr)
+    sp.call(cmdstr, shell=True)
+

--- a/scripts/SLF123/binarize.sh
+++ b/scripts/SLF123/binarize.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+while getopts "b:f:" opt;do
+	case $opt in
+		b) BASEDIR="$OPTARG";;	
+		f) fsl_ver="$OPTARG";;
+	esac
+done	
+
+module load $fsl_ver
+
+# for loop for subjects in the DB
+for proj in $(cat ${BASEDIR}/subjectList.txt);do
+
+printf "Working on $proj \n"
+
+for ROI in $(cat ${BASEDIR}/roisList.txt);do
+
+printf "Binarizing $ROI $"
+fslmaths $BASEDIR/$proj/ROIs/$ROI-MNISegment-linear.nii.gz -bin $BASEDIR/$proj/ROIs/$ROI-MNISegment-linear-binary.nii.gz
+
+done
+done

--- a/scripts/SLF123/config.json
+++ b/scripts/SLF123/config.json
@@ -1,16 +1,16 @@
 {
     "config": {
-        "basedir": "/export/home/llecca/llecca/Scripts/SLF123",
-        "codedir":"/export/home/llecca/llecca/Scripts/SLF123/codes",	
+        "basedir": "/export/home/llecca/public/Gari/SLF123",
+        "codedir":"/export/home/llecca/public/Gari/SLF123/codes",	
         "MNIpackage": "MNI_JHU_tracts_ROIs_transformed2MNI152_withPeds",
         "MNItemplate":"FSL_MNI152_FreeSurferConformed_1mm",
         "logdir":"/export/home/llecca/llecca/logs/SLF123",
-		"host":"BCBL",
-		"qsub":"true",
-        "script":"skullStripping.sh"	
+        "host":"BCBL",
+        "qsub":"true",
+        "script":"registration.sh"	
     },
     "BCBL": {
-		"mem":"60G",
+        "mem":"60G",
         "que":"short.q",
 		"ants_ver":"ants/latest",
 		"mrtrix_ver":"mrtrix3/oct2019",
@@ -23,7 +23,7 @@
 		"que":"bcbl",
 		"ants_ver":"ANTs/2.3.5-foss-2019b-Python-3.7.4",
 		"fsl_ver":"FSL/6.0.0-foss-2018b",
-		"mrtrix_ver":"mrtrix3/latest",
+		"mrtrix_ver":"MRtrix/3.0.0-foss-2020a-Python-3.8.2",
 		"gcc_ver":"GCC/9.3.0",
 		"core":6
     }

--- a/scripts/SLF123/config.json
+++ b/scripts/SLF123/config.json
@@ -12,19 +12,19 @@
     "BCBL": {
         "mem":"60G",
         "que":"short.q",
-		"ants_ver":"ants/latest",
-		"mrtrix_ver":"mrtrix3/oct2019",
-		"fsl_ver":"fsl/6.0.3",
-		"gcc_ver":"gcc/7.3.0",
-		"core":6
+	"ants_ver":"ants/latest",
+	"mrtrix_ver":"mrtrix3/oct2019",
+	"fsl_ver":"fsl/6.0.3",
+	"gcc_ver":"gcc/7.3.0",
+	"core":6
     },
     "DIPC": {
-		"mem":"100G",
-		"que":"bcbl",
-		"ants_ver":"ANTs/2.3.5-foss-2019b-Python-3.7.4",
-		"fsl_ver":"FSL/6.0.0-foss-2018b",
-		"mrtrix_ver":"MRtrix/3.0.0-foss-2020a-Python-3.8.2",
-		"gcc_ver":"GCC/9.3.0",
-		"core":6
+	"mem":"100G",
+	"que":"bcbl",
+	"ants_ver":"ANTs/2.3.5-foss-2019b-Python-3.7.4",
+	"fsl_ver":"FSL/6.0.0-foss-2018b",
+	"mrtrix_ver":"MRtrix/3.0.0-foss-2020a-Python-3.8.2",
+	"gcc_ver":"GCC/9.3.0",
+	"core":6
     }
 }

--- a/scripts/SLF123/probabilisticMaps/binarizeMaps.m
+++ b/scripts/SLF123/probabilisticMaps/binarizeMaps.m
@@ -1,0 +1,61 @@
+function roi_thres = binarizeMaps(BASEDIR,roisList,folderoutput,...
+    name2read,name2save,nameAllROis2save)
+
+% This function binarize the probabilistic maps and save a nifti with all
+% the ROIs added together, so we can find where there are voxels with
+% more than 1 ROI, e.g., >1
+% -------------------------------------------------------------------------
+% BASEDIR:      directory where is your data and the roisList.txt and
+%               the subjectList.txt
+% roisLIst:     .txt file name containing your ROIs names (do not include
+%               the extension)
+% folderoutput: folder where are the probabilistic maps.
+% name2read:    it is the suffix of the name of the ROI to read, 
+%               e.g. -MNISegment
+% name2save:    it is the suffix of the name of the map to save, e.g. -map
+% nameAllROis2save: it is the suffix of the name of the map with all the 
+%                   ROIs added together
+% -------------------------------------------------------------------------
+% OUTPUT:
+% roi_thres: you can save this variable which contains the ROI with all the
+% ROIs added together. this is useful to detect voxels contianing more than
+% 1 ROI, e.g., in the data this voxels will have a value higher than 1
+% -------------------------------------------------------------------------
+
+fileID = fopen(fullfile(BASEDIR,strcat(roisList,'.txt')));
+tlineRoi = fgetl(fileID);
+
+roi_thres = 0;
+
+% binarize the ROIs
+while ischar(tlineRoi)
+    fprintf('Loading ROI %s \n',tlineRoi)
+    roiFullPath = fullfile(BASEDIR,folderoutput,strcat(tlineRoi,...
+        name2read,'.nii.gz'));
+    % read probabilistic map
+    roi = niftiRead(roiFullPath);
+    % set zero for values under zero
+    roi.data(roi.data<0)=0;
+    % set one for values above zero
+    roi.data(roi.data>0)=1;
+    roi_bin = roi.data;
+    
+    roi_thres = roi_thres + roi_bin;
+    
+    roi.cal_min = min(roi_bin(:));
+    roi.cal_max = max(roi_bin(:));
+    roi.fname = fullfile(BASEDIR,folderoutput,...
+        strcat(tlineRoi,name2save,'.nii.gz'));
+    writeFileNifti(roi)
+    tlineRoi = fgetl(fileID);
+end
+roi.data = roi_thres;
+roi.cal_min = min(roi_thres(:));
+roi.cal_max = max(roi_thres(:));
+roi.fname = fullfile(BASEDIR,folderoutput,...
+    strcat(nameAllROis2save,'.nii.gz'));
+writeFileNifti(roi);
+fclose(fileID);
+
+end
+

--- a/scripts/SLF123/probabilisticMaps/cleanMaps.m
+++ b/scripts/SLF123/probabilisticMaps/cleanMaps.m
@@ -1,0 +1,52 @@
+function cleanMaps(BASEDIR,roisList,folderoutput,idx,name2read,...
+    name2save,row,col,z)
+
+% This function selects one ROI for the voxels with more than one ROI
+% It selects the ROI with higher subjects for that voxel
+% -------------------------------------------------------------------------
+% BASEDIR:      directory where is your data and the roisList.txt and
+%               the subjectList.txt
+% roisList:     .txt file name containing your ROIs names (do not include
+%               the extension)
+% folderoutput: folder where to save the generated probabilistic maps. If
+%               it does not exist, this function creates the folder.
+% idx:          index refering the winner ROI for the voxel containing more
+%               than one ROI
+% name2read:    it is the suffix of the name of the ROI to read, 
+%               e.g. -MNISegment
+% name2save:    it is the suffix of the name of the map to save, e.g. -map
+% row:          idx of the rows containing more than 1 voxel
+% col:          idx of the columns contianing more than 1 voxel
+% z:            idx of the heigh contaning more than 1 voxel
+% -------------------------------------------------------------------------
+
+fileID = fopen(fullfile(BASEDIR,strcat(roisList,'.txt')));
+tlineRoi = fgetl(fileID);
+count=0;
+
+maps_dir = fullfile(BASEDIR,folderoutput);
+
+while ischar(tlineRoi)
+    fprintf('Loading ROI %s \n',tlineRoi);
+    count=count+1;
+    
+    [a,~]=find(idx==count);
+    a=setdiff(1:length(idx),a);
+    
+    roiFullPath = fullfile(BASEDIR,folderoutput,strcat(tlineRoi,...
+        name2read,'.nii.gz'));
+    roi = niftiRead(roiFullPath);
+    for i=1:length(a)
+        roi.data(row(a(i)),col(a(i)),z(a(i)))=0;
+    end
+    roi_bin=roi.data;
+    roi.cal_min = min(roi_bin(:));
+    roi.cal_max = max(roi_bin(:));
+    roi.fname = fullfile(maps_dir,strcat(tlineRoi,name2save,'.nii.gz'));
+    writeFileNifti(roi)
+    
+    tlineRoi = fgetl(fileID);
+end
+
+end
+

--- a/scripts/SLF123/probabilisticMaps/countVoxels.m
+++ b/scripts/SLF123/probabilisticMaps/countVoxels.m
@@ -1,0 +1,46 @@
+function rois = countVoxels(BASEDIR,roisList,subjectList,name2read,...
+    countVoxels)
+
+% This function summ all the subjects for each ROI and then locate the
+% voxels with more than 1 ROI so we can see how many votes has each ROI
+% -------------------------------------------------------------------------
+% BASEDIR:      directory where is your data and the roisList.txt and
+%               the subjectList.txt
+% roisList:     .txt file name containing your ROIs names (do not include
+%               the extension)
+% subjectList:  .txt file containig your subjectList names (do not include
+%               the extension)
+% name2read:    it is the suffix of the name of the ROI to read, 
+%               e.g. -MNISegment
+% countVoxels:  name of the .mat file to save. It contains the struct
+%               counting how many subjects are for each voxel and for each
+%               ROI of the ROIsList
+% -------------------------------------------------------------------------
+
+fileID = fopen(fullfile(BASEDIR,strcat(roisList,'.txt')));
+tlineRoi = fgetl(fileID);
+
+roisum = 0;
+
+while ischar(tlineRoi)
+    fprintf('Loading ROI %s \n',tlineRoi)
+    fileIDsub = fopen(fullfile(BASEDIR,strcat(subjectList,'.txt')));
+    tlinesub = fgetl(fileIDsub);
+    while ischar(tlinesub)
+        fprintf('Subject %s \n',tlinesub)
+        input_dir = fullfile(BASEDIR,tlinesub,'ROIs');
+        roiFullPath = fullfile(input_dir,strcat(tlineRoi,name2read,...
+            '.nii.gz'));
+        % read roi for subject
+        roi = niftiRead(roiFullPath);
+        roisum = roi.data + roisum;
+        tlinesub = fgetl(fileIDsub);
+    end
+    fclose(fileIDsub);
+    rois.(tlineRoi)=roisum; roisum=0;
+    tlineRoi = fgetl(fileID);
+end
+fclose(fileID);
+save(fullfile(BASEDIR,strcat(countVoxels,'.mat')),'rois');
+
+end

--- a/scripts/SLF123/probabilisticMaps/probMapGeneration.m
+++ b/scripts/SLF123/probabilisticMaps/probMapGeneration.m
@@ -1,0 +1,69 @@
+function probMapGeneration(BASEDIR,roisList,subjectList,folderoutput,...
+    name2read,name2save)
+
+% This function generates probabilistc maps from all the subjects defined 
+% in the subjectList.txt. It will be a map for each ROI denfined in the
+% ROIsList.txt
+% -------------------------------------------------------------------------
+% BASEDIR:      directory where is your data and the roisList.txt and
+%               the subjectList.txt
+% roisLIst:     .txt file name containing your ROIs names (do not include
+%               the extension)
+% subjectList:  .txt file containig your subjectList names (do not include
+%               the extension)
+% folderoutput: folder where to save the generated probabilistic maps. If
+%               it does not exist, this function creates the folder.
+% name2read:    it is the suffix of the name of the ROI to read, 
+%               e.g. -MNISegment
+% name2save:    it is the suffix of the name of the map to save, e.g. -map
+% -------------------------------------------------------------------------
+
+fileID = fopen(fullfile(BASEDIR,strcat(roisList,'.txt')));
+tlineRoi = fgetl(fileID);
+
+roiprob = 0;
+counter = 0;
+
+% create probabilisticMaps folder if does not exist
+maps_dir = fullfile(BASEDIR,folderoutput);
+if ~exist(maps_dir,'dir')
+    mkdir(maps_dir);
+end
+
+while ischar(tlineRoi)
+    fprintf('Loading ROI %s for all subjects list \n',tlineRoi)
+    
+    fileIDsub = fopen(fullfile(BASEDIR,strcat(subjectList,'.txt')));
+    tlinesub = fgetl(fileIDsub);
+    
+    while ischar(tlinesub)
+        input_dir = fullfile(BASEDIR,tlinesub,'ROIs');
+        roiFullPath = fullfile(input_dir,strcat(tlineRoi,...
+            name2read,'.nii.gz'));
+        % read roi for subject
+        roi = niftiRead(roiFullPath);
+        % set zero for values under zero
+        roi.data(roi.data<0)=0;
+        roi.data = roi.data ./ max(roi.data(:));
+        % add subject data to the roi
+        roiprob = roi.data+roiprob;
+        % subject counter
+        counter = counter+1; disp(counter);
+        tlinesub = fgetl(fileIDsub);
+    end
+    fclose(fileIDsub); 
+    roiprob = (roiprob ./ counter).*100;
+    % change img data
+    roi.data = round(roiprob);
+    roi.cal_min = min(roiprob(:));
+    roi.cal_max = max(roiprob(:));
+    roi.fname = fullfile(maps_dir,strcat(tlineRoi,name2save,'.nii.gz'));
+    writeFileNifti(roi)
+    roiprob = 0;
+    counter = 0;
+    tlineRoi = fgetl(fileID);
+end
+fclose(fileID);
+
+end
+

--- a/scripts/SLF123/probabilisticMaps/votingMtrx.m
+++ b/scripts/SLF123/probabilisticMaps/votingMtrx.m
@@ -1,0 +1,35 @@
+function voting = votingMtrx(BASEDIR,roisList,rois,row,col,z)
+
+% This function generates the voting array (i.e., the array counting how
+% many subjects for each ROI are for the voxels containing more than 1 ROI)
+% -------------------------------------------------------------------------
+% BASEDIR:  directory where is your data and the roisList.txt and the 
+%           subjectList.txt
+% roisLIst: .txt file name containing your ROIs names (do not include
+%           the extension)
+% rois:     struct containing all the ROIs added together to see the
+%           voxels with more than 1 ROI
+% row:      idx of the rows containing more than 1 voxel
+% col:      idx of the columns contianing more than 1 voxel
+% z:        idx of the heigh contaning more than 1 voxel
+% -------------------------------------------------------------------------
+
+fileID = fopen(fullfile(BASEDIR,strcat(roisList,'.txt')));
+tlineRoi = fgetl(fileID);
+
+voting = zeros(length(z),size(struct2table(rois),2));
+count=0;
+
+while ischar(tlineRoi)
+    fprintf('Loading ROI %s \n',tlineRoi);
+    roi = rois.(tlineRoi);
+    count=count+1;
+    for t=1:length(z)
+        voting(t,count) = roi(row(t),col(t),z(t));
+    end
+    tlineRoi = fgetl(fileID);
+end
+fclose(fileID);
+
+end
+

--- a/scripts/SLF123/runANTsApplyTransforms.sh
+++ b/scripts/SLF123/runANTsApplyTransforms.sh
@@ -11,19 +11,18 @@ printf "#### roi directory: $roidir \n"
 printf "#### reference image: $ref \n"
 printf "#### transform1: $transform1 \n"
 printf "#### transform2: $transform2 \n"
+printf "#### BASEDIR: $BASEDIR \n"
 
-for ROI in $roidir/*.nii.gz;do
-roiname=$(basename $ROI)
-roiname=${roiname%%.*}
+for ROI in $(cat $BASEDIR/roisList.txt);do
 
-printf "Transforming $roiname \n"
+printf "Transforming $ROI \n"
 
 antsApplyTransforms -d 3 \
--i $ROI \
+-i $roidir/$ROI.nii.gz \
 -r $ref \
--n BSpline \
+-n linear \
 -t $transform1 \
 -t $transform2 \
--o $roidir/${roiname}-MNISegment.nii.gz
+-o $roidir/$ROI-MNISegment-linear.nii.gz
 
 done

--- a/scripts/SLF123/transform.sh
+++ b/scripts/SLF123/transform.sh
@@ -41,7 +41,7 @@ qsub -q $que -N sub_${proj}_transform \
      -o ${logdir}/${proj}_transform.o \
      -e ${logdir}/${proj}_transform.e \
      -l mem_free=$mem \
-     -v roidir=${ROI_DIR},MRI_DIR=${MRI_DIR},ants_ver=$ants_ver \
+     -v roidir=${ROI_DIR},MRI_DIR=${MRI_DIR},ants_ver=$ants_ver,BASEDIR=${BASEDIR} \
      ${codedir}/runANTsApplyTransforms.sh	
 fi
 
@@ -51,13 +51,13 @@ qsub -q $que -l mem=$mem,nodes=1:ppn=$core \
 	-N sub_$[proj]_transform \
 	-o ${logdir}/${proj}_transform.o \
 	-e ${logdir}/${proj}_transform.e \
-	-v roidir=${ROI_DIR},MRI_DIR=${MRI_DIR},ants_ver=$ants_ver \
+	-v roidir=${ROI_DIR},MRI_DIR=${MRI_DIR},ants_ver=$ants_ver,BASEDIR={$BASEDIR} \
 	${codedir}/runANTsApplyTransforms.sh
 fi
 
 else
 antsApplyTransforms -d 3 \
--i ${ROI} \
+-i ${ROI_DIR}/${roiname}.nii.gz \
 -r ${MRI_DIR}/antsWarped.nii.gz \
 -n BSpline \
 -t ${MRI_DIR}/ants1Warp.nii.gz \


### PR DESCRIPTION
probabilisticMap folder: it contains all the matlab functions needed for the probabilisticMap.m

This new version includes the probabilisticMap folder which contains the Matlab functions for cleaning the probabilistic maps, i.e., select one ROI for the voxels that are labeled with more than one ROI (i.e., it selects the ROI with higher number of subjects).